### PR TITLE
fix ModuleNotFoundError, NonPrefixFileNotExistError errors

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include trtokenizer*

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include trtokenizer*
+recursive-include trtokenizer *

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     # packages=['trtopicter'],
     packages=find_packages(),
     include_package_data=True,
-    version='0.0.2',
+    version='0.0.3',
     license='MIT',
     description='Sentence and word tokenizers for the Turkish language',
     long_description_content_type='text/markdown',
@@ -21,6 +21,7 @@ setup(
     author_email='apdullahyayik@gmail.com',
     url='https://github.com/apdullahyayik/TrTokenizer',
     download_url='https://github.com/apdullahyayik/TrTokenizer/archive/v0.0.2.tar.gz',
+    include_package_data = True,
     keywords=['sentence tokenizer', 'word tokenizer', 'Turkish language', 'natural language processing'],
     install_requires=['regex'],
     python_requires='>=3.4'

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
     author_email='apdullahyayik@gmail.com',
     url='https://github.com/apdullahyayik/TrTokenizer',
     download_url='https://github.com/apdullahyayik/TrTokenizer/archive/v0.0.2.tar.gz',
-    include_package_data = True,
     keywords=['sentence tokenizer', 'word tokenizer', 'Turkish language', 'natural language processing'],
     install_requires=['regex'],
     python_requires='>=3.4'

--- a/trtokenizer/__init__.py
+++ b/trtokenizer/__init__.py
@@ -1,2 +1,4 @@
 __author____ = 'Apdullah Yayık'
-__version__ = '0.0.1'
+__version__ = '0.0.3'
+
+from trtokenizer.tr_tokenizer import SentenceTokenizer, WordTokenizer

--- a/trtokenizer/tr_tokenizer.py
+++ b/trtokenizer/tr_tokenizer.py
@@ -53,7 +53,7 @@ class SentenceTokenizer:
 
         """
 
-        self.non_breaking_prefix_file: str
+        self.non_breaking_prefix_file: str = non_breaking_prefix_file
         self.__non_breaking_prefixes: dict
         self.pre_compiled_regexes: dict
         line: str

--- a/trtokenizer/tr_tokenizer.py
+++ b/trtokenizer/tr_tokenizer.py
@@ -8,6 +8,7 @@ __all__ = ['SentenceTokenizer', 'WordTokenizer']
 __version__ = '0.0.0.1'
 
 import os
+import pathlib
 from enum import Enum
 from typing import Optional, Tuple, Union
 
@@ -59,9 +60,8 @@ class SentenceTokenizer:
         prefix_type: int
         item: int
 
-        self.non_breaking_prefix_file = os.path.join(
-            re.search(pattern=r'(?P<folder_name>.*)/tr_tokenizer\.py', string=__file__
-                      )['folder_name'], 'tr_non_suffixes'
+        self.non_breaking_prefix_file = str(
+            pathlib.Path(__file__).parent.resolve() / "tr_non_suffixes"
         )
 
         if not os.path.isfile(self.non_breaking_prefix_file):

--- a/trtokenizer/tr_tokenizer.py
+++ b/trtokenizer/tr_tokenizer.py
@@ -38,7 +38,7 @@ class SentenceTokenizer:
         else:
             return f'Sentence tokenizer not integrated with look-up table'
 
-    def __init__(self):
+    def __init__(self, non_breaking_prefix_file: str = None):
         """Sentence tokenizer
 
         Parameters
@@ -60,9 +60,10 @@ class SentenceTokenizer:
         prefix_type: int
         item: int
 
-        self.non_breaking_prefix_file = str(
-            pathlib.Path(__file__).parent.resolve() / "tr_non_suffixes"
-        )
+        if self.non_breaking_prefix_file is None:
+            self.non_breaking_prefix_file = str(
+                pathlib.Path(__file__).parent.resolve() / "tr_non_suffixes"
+            )
 
         if not os.path.isfile(self.non_breaking_prefix_file):
             raise NonPrefixFileNotExistError(self.non_breaking_prefix_file)

--- a/trtokenizer/tr_tokenizer.py
+++ b/trtokenizer/tr_tokenizer.py
@@ -13,7 +13,7 @@ from typing import Optional, Tuple, Union
 
 import regex as re
 
-from errors import NonPrefixFileNotExistError
+from trtokenizer.errors import NonPrefixFileNotExistError
 
 
 class SentenceTokenizer:


### PR DESCRIPTION
@apdullahyayik thanks a lot for this awesome package! I am trying to integrate it to my NLP research project but having numerous errors. Merging this PR and releasing v0.0.3 would help me a lot!

This PR:
- fixes ModuleNotFoundError on ```from TrTokenizer import SentenceTokenize, WordTokenize``` by fixing an import and updating the `__init__.py` file
- fixes NonPrefixFileNotExistError by adding a `MANIFEST.in` file
- adds optional `non_breaking_prefix_file` init parameter to SentenceTokenizer